### PR TITLE
Anula commit 9d893ed y 2c39727 

### DIFF
--- a/WebApp/App_Start/BundleConfig.cs
+++ b/WebApp/App_Start/BundleConfig.cs
@@ -12,9 +12,7 @@ namespace WebApp.App_Start
         public static void RegisterBundles(BundleCollection bundles)
         {
             bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
-                        "~/Scripts/jquery-3.*",
-                        "~/Scripts/jquery.validate.unobtrusive.js",
-                        "~/Scripts/jquery.validate.js"));
+                        "~/Scripts/jquery-3.*"));
 
             bundles.Add(new ScriptBundle("~/bundles/dataTables").Include(
                         "~/Scripts/DTables/datatables.min.js",

--- a/WebApp/Scripts/jquery.validate.js
+++ b/WebApp/Scripts/jquery.validate.js
@@ -1462,7 +1462,8 @@ $.extend( $.validator, {
 
 		// https://jqueryvalidation.org/number-method/
 		number: function( value, element ) {
-			return this.optional( element ) || /^(?:-?\d+|-?\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test( value );
+			return this.optional(element) || /^(?:-?\d+|-?\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test(value);     // Esta es la linea original
+			return this.optional(element) || /^(?:-?\d+|-?\d{1,3}(?:,\d{3})+)?(?:\,\d+)?$/.test(value);     // Esta es la modificación
 		},
 
 		// https://jqueryvalidation.org/digits-method/
@@ -1655,7 +1656,3 @@ if ( $.ajaxPrefilter ) {
 }
 return $;
 }));
-
-$.validator.methods.number = function (value, element) {
-	return this.optional(element) || /^-?(?:\d+|\d{1,3}(?:\.\d{3})+)?(?:,\d+)?$/.test(value);
-}

--- a/WebApp/Scripts/jquery.validate.unobtrusive.js
+++ b/WebApp/Scripts/jquery.validate.unobtrusive.js
@@ -430,7 +430,3 @@
 
     return $jQval.unobtrusive;
 }));
-
-$.validator.methods.number = function (value, element) {
-    return this.optional(element) || /^-?(?:\d+|\d{1,3}(?:\.\d{3})+)?(?:,\d+)?$/.test(value);
-}

--- a/WebApp/Views/Shared/BaseLayout.cshtml
+++ b/WebApp/Views/Shared/BaseLayout.cshtml
@@ -8,6 +8,8 @@
 
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/jquery")
+    <script src="~/Scripts/jquery.validate.js"></script>
+    <script src="~/Scripts/jquery.validate.unobtrusive.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
Se corrige la validación del Monto en ModificarGasto y AgregarGasto lado del Cliente 
- Se borra código agregado al final de los archivos "jquery.validate" y "jquery.validate.unobstrusive"
- Se corrije la expresión regular de Jquery modificando la linea 1465 por la 1466
- Se sacan los archivos mencionados anteriormente del "BundleConfig.cs"
- Y son agregados en "BaseLayout.cshtml"

Estando los archivos bundeados, por mas que esta corregida la expresion regular, no funciona como deberia hacerlo, por eso se sacan del Bundle y se los deja sueltos en el BaseLayout
